### PR TITLE
refactor!: add nullability to geojson point fields

### DIFF
--- a/lib/src/models/geo_json_point.dart
+++ b/lib/src/models/geo_json_point.dart
@@ -1,12 +1,12 @@
 class GeoJsonPoint {
   List<double>? boundingBox;
-  List<double> coordinates;
-  String type;
+  List<double>? coordinates;
+  String? type;
 
   GeoJsonPoint({
     this.boundingBox,
-    required this.coordinates,
-    required this.type,
+    this.coordinates,
+    this.type,
   });
 
   factory GeoJsonPoint.fromJson(
@@ -16,10 +16,10 @@ class GeoJsonPoint {
       boundingBox: (json['bbox'] as List<dynamic>?)
           ?.map((e) => (e as num).toDouble())
           .toList(),
-      coordinates: (json['coordinates'] as List<dynamic>)
-          .map((e) => (e as num).toDouble())
+      coordinates: (json['coordinates'] as List<dynamic>?)
+          ?.map((e) => (e as num).toDouble())
           .toList(),
-      type: json['type'] as String,
+      type: json['type'] as String?,
     );
   }
 


### PR DESCRIPTION
BREAKING CHANGE: The previously required fields in the `GeoJsonPoint` model class are now nullable.

Closes #5